### PR TITLE
Enable autofill

### DIFF
--- a/src/pages/vendor/draft-vendor-order-page/components/VendorOrderForm.tsx
+++ b/src/pages/vendor/draft-vendor-order-page/components/VendorOrderForm.tsx
@@ -75,7 +75,7 @@ export default function VendorOrderForm({
   onClear,
 }) {
   const navigate = useNavigate();
-  const [page, setPage] = useState(edit ? 1 : 1);
+  const [page, setPage] = useState(edit ? 1 : 0);
   // The products we visually see in the form.
   const [selectedProducts, setSelectedProducts] = useState(() =>
     computeSelectedProducts(allProducts, existingProducts)

--- a/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormPage0.tsx
+++ b/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormPage0.tsx
@@ -106,8 +106,7 @@ export default function VendorOrderFormPage0({
               if (file.type.startsWith("image/")) {
                 try {
                   const compressedFile = await imageCompression(file, {
-                    maxSizeMB: 0.5,
-                    maxWidthOrHeight: 768,
+                    maxSizeMB: 0.1,
                     signal: imageCompressAborter.current.signal,
                     onProgress: (progress) => {
                       if (progress < 100) {

--- a/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormPage2.tsx
+++ b/src/pages/vendor/draft-vendor-order-page/components/VendorOrderFormPage2.tsx
@@ -254,8 +254,7 @@ export default function VendorOrderFormPage2({
                   if (file.type.startsWith("image/")) {
                     try {
                       const compressedFile = await imageCompression(file, {
-                        maxSizeMB: 0.5,
-                        maxWidthOrHeight: 768,
+                        maxSizeMB: 0.1,
                         signal: imageCompressAborter.current.signal,
                         onProgress: (progress) => {
                           if (progress < 100) {


### PR DESCRIPTION
- Enable autofill
  - Only merge this PR after the backend PR is merged
- Revert to old compression level
  - The dimension compression is too aggressive, leading to pictures taken from iPhone very difficult to see